### PR TITLE
Add admin user management routes

### DIFF
--- a/node-app/README.md
+++ b/node-app/README.md
@@ -69,6 +69,9 @@ The server exposes the following endpoints:
 - `DELETE /board/:id` – remove board post (`?key=ADMIN_KEY`)
 - `GET /admin/broken` – list broken link reports (`?key=ADMIN_KEY`)
 - `POST /admin/broken/:id/resolve` – mark broken report resolved (`?key=ADMIN_KEY`)
+- `GET /admin/users` – list all users (`?key=ADMIN_KEY`)
+- `DELETE /admin/users/:id` – delete a user (`?key=ADMIN_KEY`)
+- `PATCH /admin/users/:id` – edit user data (`?key=ADMIN_KEY`)
 - `POST /wallet/login` – login via wallet signature (`{address, signature}`)
 - `GET /wallet/collection/:address` – NFT token IDs owned by the wallet
 

--- a/node-app/index.js
+++ b/node-app/index.js
@@ -6,7 +6,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import songsRouter from './routes/songs.js';
-import usersRouter from './routes/users.js';
+import usersRouter, { adminRouter as usersAdminRouter } from './routes/users.js';
 import playlistsRouter from './routes/playlists.js';
 import boardRouter from './routes/board.js';
 import walletRouter from './routes/wallet.js';
@@ -74,6 +74,7 @@ app.use('/playlists', playlistsRouter);
 app.use('/board', boardRouter);
 app.use('/wallet', walletRouter);
 app.use('/admin', adminRouter);
+app.use('/admin', usersAdminRouter);
 
 app.get('/', (req, res) => {
   res.send('Some Songs API');


### PR DESCRIPTION
## Summary
- manage users via admin router
- document new admin user endpoints

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846cf7f40b88329ba498f49f8db9154